### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides Claude Desktop with direct access to your local file system for development tasks. This tool enables Claude to read, write, edit files, run commands, and search through your codebase.
 
+<a href="https://glama.ai/mcp/servers/@talentedmrweb/local-dev-bridge-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@talentedmrweb/local-dev-bridge-mcp/badge" alt="Local Dev Bridge MCP server" />
+</a>
+
 ## Features
 
 - 📖 **Read files** - View contents of any file in your project


### PR DESCRIPTION
This PR adds a badge for the [Local Dev Bridge MCP](https://glama.ai/mcp/servers/@talentedmrweb/local-dev-bridge-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@talentedmrweb/local-dev-bridge-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@talentedmrweb/local-dev-bridge-mcp/badge" alt="Local Dev Bridge MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.